### PR TITLE
add integer parsing based off https://github.com/nodejs/llparse/pull/32 And Fix Pausing

### DIFF
--- a/llparse/compilator.py
+++ b/llparse/compilator.py
@@ -501,7 +501,7 @@ class Pause(Error):
 
         assert self.ref.otherwise
         otherwise = ctx.unwrapNode(self.ref.otherwise.node)
-        out.append(f"{ctx.currentField()} = (void*) (intptr_t) {otherwise};")
+        out.append(f"{ctx.currentField()} = (void*) (intptr_t) {otherwise.cachedDecel};")
         out.append(f"return {STATE_ERROR};")
 
 
@@ -1235,13 +1235,14 @@ class Compilation:
             r = Consume(ref)
         elif isinstance(ref, _frontend.node.Empty):
             r = Empty(ref)
+        elif isinstance(ref, _frontend.node.Pause):
+            r = Pause(ref)
+
         elif isinstance(ref, _frontend.node.Error):
             r = Error(ref)
         elif isinstance(ref, _frontend.node.Invoke):
             r = Invoke(ref)
-        elif isinstance(ref, _frontend.node.Pause):
-            r = Pause(ref)
-
+        
         elif isinstance(ref, _frontend.node.SpanStart):
             r = SpanStart(ref)
 

--- a/llparse/frontend.py
+++ b/llparse/frontend.py
@@ -211,7 +211,7 @@ class Frontend:
             result = nodeImpl.Error(_frontend.node.Error(ID(), node.code, node.reason))
 
         elif isinstance(node, source.code.Pause):
-            result = nodeImpl.Pause(_frontend.node.Error(ID(), node.code, node.reason))
+            result = nodeImpl.Pause(_frontend.node.Pause(ID(), node.code, node.reason))
 
         elif isinstance(node, source.code.Comsume):
             result = nodeImpl.Consume(_frontend.node.Consume(ID(), node.field))

--- a/llparse/pybuilder/__init__.py
+++ b/llparse/pybuilder/__init__.py
@@ -1,2 +1,8 @@
 from ..pybuilder.builder import *
 from ..pybuilder.loopchecker import *
+from ..pybuilder.main_code import (
+# I'll add more soon I feel a little lazy at the moment.
+    Node,
+    Match,
+    Int
+)

--- a/llparse/pybuilder/builder.py
+++ b/llparse/pybuilder/builder.py
@@ -1,7 +1,8 @@
 from typing import Literal, Optional, Union
-
 from ..pybuilder import main_code as code
 
+# typehinting node and code (TODO: Vizonex) Lets seperate the modules soon...
+node = code
 # from pydot import graph_from_dot_data
 
 
@@ -316,3 +317,38 @@ class Builder:
     def properties(self) -> list[Property]:
         """Return list of all allocated properties in parser's state."""
         return list(self.privProperties.values())
+
+    def intBE(self, field: str, bits:int):
+        """
+        :param field: State's property name
+        :param bits: Number of bits to use
+        """
+        return code.Int(field, bits, True, False)
+
+    def intLE(self, field: str, bits: int):
+        """
+        return a node for unpacking arrays to integers
+
+        :param field: State's property name
+        :param bits: Number of bits to use
+        """
+        return code.Int(field, bits, True, True)
+
+    def uintBE(self, field: str, bits: int):
+        """
+        return a node for unpacking arrays to integers
+        
+        :param field: State's property name
+        :param bits: Number of bits to use
+        """
+        return code.Int(field, bits, False, False)
+
+    def uintLE(self, field: str, bits: int):
+        """
+        return a node for unpacking arrays to integers
+        
+        :param field: State's property name
+        :param bits: Number of bits to use
+        """
+        return code.Int(field, bits, False, True)
+    

--- a/llparse/pybuilder/loopchecker.py
+++ b/llparse/pybuilder/loopchecker.py
@@ -252,7 +252,7 @@ class LoopChecker:
                 return
 
         for edge in node.getAllEdges():
-            if edge.noAdvance:
+            if not edge.noAdvance:
                 continue
             edgeValue = value
             if edge.key is None or isinstance(edge.key, int):

--- a/llparse/pybuilder/loopchecker.py
+++ b/llparse/pybuilder/loopchecker.py
@@ -252,7 +252,7 @@ class LoopChecker:
                 return
 
         for edge in node.getAllEdges():
-            if not edge.noAdvance:
+            if edge.noAdvance:
                 continue
             edgeValue = value
             if edge.key is None or isinstance(edge.key, int):

--- a/llparse/pybuilder/main_code.py
+++ b/llparse/pybuilder/main_code.py
@@ -92,6 +92,8 @@ class _Match(Code):
         super().__init__("match", name)
 
 
+
+
 @dataclass
 class IMulAddOptions:
     base: int
@@ -243,6 +245,39 @@ class Invoke(Node):
                 )
             self.addEdge(Edge(targetNode, True, numKey, None))
 
+
+
+# Not in llparse node-js (yet) But I wanted to implement 
+# this into my version since I am making a very important 
+# http2 frame parser
+
+# SEE: https://github.com/nodejs/llparse-frontend/pull/1
+
+def build_name(field:str, bits: int, signed:bool, little_endian:bool) -> str:
+    result = f"{field}_{'int' if signed else 'uint'}_{bits * 8}"
+    if bits > 1:
+        return result + ('_le' if little_endian else 'be')
+    else:
+        return result
+
+
+class Int(Node):
+    """Used for parsing bytes via unpacking"""
+    def __init__(self, field: str, bits: int, signed: bool, little_endian: bool) -> None:
+        """
+        :param field: State's property name
+        :param bits: Number of bits to use
+        :param signed: Number is signed 
+        :param little_endian: true if le, false if be
+        """
+        if bits < 0:
+            raise ValueError("bits should be a positive integer")
+        self.field =  field
+        self.bits = bits
+        self.signed = signed
+        self.little_endian  = little_endian
+        super().__init__(build_name(field, bits, signed, little_endian))
+    
 
 # -- Transfroms --
 

--- a/llparse/pyfront/front.py
+++ b/llparse/pyfront/front.py
@@ -14,9 +14,6 @@ Signature = TypeVar("Signature", bytes, str)
 class IWrap(Generic[T]):
     ref: T
 
-    # def __hash__(self) -> int:
-    #     return hash(self.ref)
-
 
 def toCacheKey(value: Union[int, bool]) -> str:
     if isinstance(value, int):

--- a/llparse/pyfront/implementation.py
+++ b/llparse/pyfront/implementation.py
@@ -37,6 +37,9 @@ class INodeImplementation:
 
     def TableLookup(self, n: node.TableLookup):
         return IWrap(n)
+    
+    def Int(self, n: node.Int):
+        return IWrap(n)
 
 
 class ITransformImplementation:

--- a/llparse/pyfront/nodes.py
+++ b/llparse/pyfront/nodes.py
@@ -153,6 +153,26 @@ class Pause(Error):
         super().__init__(id, code, reason)
 
 
+# Not in llparse node-js (yet) But I wanted to implement 
+# this into my version since I am making a very important 
+# http2 frame parser
+
+# SEE: https://github.com/nodejs/llparse-frontend/pull/1
+
+@dataclass
+class Int(Node):
+    field: str
+    bits: int
+    signed: bool
+    littleEndian: bool
+    byteOffset: int
+
+    def __hash__(self):
+        return hash(self.id)
+
+
+
+
 @dataclass
 class ISeqEdge:
     node: IWrap[Node]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llparse"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Parody of llparse written for writing C Parsers with Python"
 readme = "README.md"
 authors = [

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -22,4 +22,14 @@ def test_build_tables():
     assert "lookup_table" in p.build(start).c
 
 
+def test_pausing():
+    # Ensure frotentend LoopChecker does not mark off against Pausing
+    p = LLParse("lltest")
+    s = p.node('start')
+    s2 = p.node('start2')
+    s.match('p', p.pause(1, 'parser was asked to pause').otherwise(s2)).skipTo(s)
+    s2.match('p', p.pause(2, 'parser was asked to pause again').otherwise(s)).skipTo(s2)
+    
+    p.build(s)
 
+    


### PR DESCRIPTION
I'm going to add in integer parsing myself based off @arthurschreiber but with Indutny's requested features and nitpicks. 
I will need to make a frame parser for http2 for the aiohttp developers soon since were looking into implementing http/2 protocols, however I would like something a little bit faster than python at parsing frames instead of what hyperframe does which is collecting 9 bits and then depacking. This will skip all of that and cut right to the juicy portions without bloating memory.

SEE: https://github.com/nodejs/llparse/pull/32 for more details.

```python
from llparse import LLParse

def main():
    p = LLParse("frame_parser")
    p.property("i32", "length")
    p.property("i32", "stream_id")
    p.property("i8", "type")
    p.property("i8", "flags")

    body_span = p.span(p.code.span("frame_parser__on_body"))

    root = p.uintBE("length", 3)
    ty = p.uintBE("type", 1)
    flags = p.uintBE("flags", 1)
    stream_id = p.uintBE("stream_id", 4)

    root.skipTo(ty)
    ty.skipTo(flags)
    flags.skipTo(stream_id)

    stream_id.skipTo(
        body_span.start(
            p.consume("length").otherwise(
                body_span.end(
                    p.pause(1, "waiting for next frame").otherwise(root)
                )
            )
        )
    )
    
    data = p.build(root)
    with open('frame_parser.c', 'w') as w:
        w.write(data.c)
    with open('frame_parser.h', 'w') as w:
        w.write(data.header)
    

if __name__ == "__main__":
    main()
```

Here's a dummy example based off RFC 9113 section 4.1
