### PR TITLE
add new Operator Code class

### DIFF
--- a/llparse/compilator.py
+++ b/llparse/compilator.py
@@ -273,6 +273,13 @@ class Update(Field):
         out.append(f"{self.field(ctx)} = {self.ref.value};")
         out.append("return 0;")
 
+class Operator(Field):
+    def __init__(self, ref: _frontend.code.Operator):
+        self.ref = ref
+    
+    def doBuild(self, ctx: "Compilation", out: list[str]):
+        out.append(f'return {self.field(ctx)} {self.ref.op} {self.ref.value};')
+
 
 @dataclass
 class INodeEdge:
@@ -1218,6 +1225,8 @@ class Compilation:
             r = Test(ref)
         elif isinstance(ref, _frontend.code.Update):
             r = Update(ref)
+        elif isinstance(ref, _frontend.code.Operator):
+            r = Operator(ref)
         else:
             raise Exception(
                 f'refrence "{ref.name}" is an Invalid Code Type , TypeName:"{ref.__class__.__name__}"'

--- a/llparse/frontend.py
+++ b/llparse/frontend.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Union
+from typing import Literal, Optional, Union, TypeVar
 
 from .enumerator import Enumerator
 from .pybuilder import LoopChecker
@@ -21,6 +21,9 @@ from logging import getLogger
 
 log = getLogger("llparse.frontend")
 
+
+CodeT = TypeVar('CodeT', bound=source.code.Code)
+NodeT = TypeVar('NodeT', bound=source.node.Node)
 
 WrappedNode = IWrap[_frontend.node.Node]
 WrappedCode = IWrap[_frontend.code.Code]
@@ -462,7 +465,7 @@ class Frontend:
         return self.translateCode(code)
 
     def translateCode(
-        self, code: source.code.Code
+        self, code: CodeT
     ):
         """Translates Builder Classes to Frontend Classes..."""
 
@@ -474,7 +477,13 @@ class Frontend:
             res = codeImpl.IsEqual(
                 _frontend.code.IsEqual(prefixed, code.field, code.value)
             )
-
+        # custom thing I added in 0.1.6 I encourage the typescript 
+        # maintainers and developers of llparse to look into this :)
+        elif isinstance(code, source.code.Operator):
+            res = codeImpl.Operator(_frontend.code.Operator(
+                prefixed, code.field, code.value, code.op
+            ))
+        
         elif isinstance(code, source.code.Load):
             res = codeImpl.Load(_frontend.code.Load(prefixed, code.field))
 

--- a/llparse/pybuilder/builder.py
+++ b/llparse/pybuilder/builder.py
@@ -36,10 +36,13 @@ class Creator:
     def __init__(self) -> None:
         return
 
-    # TODO Make Sure python llparse match api is compatable with 3.10 and above...
+    # TODO (Vizonex): I think we could add a node for property copying from a to b
+    # and addition and subtraction nodes like a counter unlike consume and I think the typescript
+    # Library could have the same features as us. I seem to come up with new nodes often
+    # which is a rare thing to see. :)
 
     # Thank goodness I can do C example documentation in here :) - Vizonex
-    def match(self, name: str):
+    def match(self, name: str) -> code.Match:
         """Create an external callback that **has no** `value` argument.
 
         This callback can be used in all `Invoke` nodes except those that are
@@ -53,14 +56,11 @@ class Creator:
 
         Where `llparse_t` is parser state's type name.
 
-        Parameters
-        ----------
-        ----------
-        - `name` External function name.
+        :param name: External function name.
         """
         return code._Match(name)
 
-    def value(self, name: str):
+    def value(self, name: str) -> code.Value:
         """
 
         Create an external callback that **has** `value` argument.
@@ -76,15 +76,12 @@ class Creator:
 
         Where `llparse_t` is parser state's type name.
 
-        Parameters
-        ----------
-        ----------
-        - `name` External function name.
+        :param name: External function name.
 
         """
         return code.Value(name)
 
-    def span(self, name: str):
+    def span(self, name: str) -> code._Span:
         """Create an external span callback.
 
         This callback can be used only in `Span` constructor.
@@ -100,30 +97,25 @@ class Creator:
 
         NOTE: non-zero return value is treated as resumable error.
 
-        Parameters
-        ----------
-        - `name` External function name.
+        :param name: External function name.
         """
         return code._Span(name)
 
-    def store(self, field: str):
+    def store(self, field: str) -> code.Store:
         """
         Intrinsic operation. Stores `value` from `.select()` node into the state's
         property with the name specified by `field`, returns zero.
 
         ```c
-           state[field] = value;
-           return 0;
+        state[field] = value;
+        return 0;
         ```
 
-        Parameters
-        ----------
-
-        - `field`  Property name
+        :param field:  Property name
         """
         return code.Store(field)
 
-    def load(self, field: str):
+    def load(self, field: str) -> code.Load:
         """Intrinsic operation. Loads and returns state's property with the name
         specified by `field`.
 
@@ -132,15 +124,14 @@ class Creator:
         ```c
            return state[field];
         ```
-        Parameters
-        ----------
-        `field`  Property name.
+
+        :param field: Property name.
         """
         return code.Load(field)
 
     def mulAdd(
         self, field: str, base: int, max: Optional[int] = None, signed: bool = False
-    ):
+    ) -> code.MulAdd:
         """Intrinsic operation. Takes `value` from `.select()`, state's property
         with the name `field` and does:
         ```c
@@ -155,24 +146,21 @@ class Creator:
             - 0 - success
             - 1 - overflow
 
-        Parameters
-        ----------
-        ----------
         Unlike in Typescript, The values of `IMulAddOptions` have been added here
         since it's Python , not Typescript
 
-        - `field`    Property name
+        :param field:    Property name
 
-        - `base` Value to multiply the property with in the first step
+        :param base: Value to multiply the property with in the first step
 
-        - `max` Maximum value of the property. If at any point of computation the
+        :param max: Maximum value of the property. If at any point of computation the
            intermediate result exceeds it - `mulAdd` returns 1 (overflow).
 
-        - `signed` If `true` - all arithmetics perfomed by `mulAdd` will be signed.
+        :param signed: If `true` - all arithmetics perfomed by `mulAdd` will be signed.
            Default value: `false`"""
         return code.MulAdd(field, base, max, signed)
 
-    def update(self, field: str, value: int):
+    def update(self, field: str, value: int) -> code.Update:
         """
 
         Intrinsic operation. Puts `value` integer into the state's property with
@@ -181,74 +169,118 @@ class Creator:
           state[field] = value;
           return 0;
 
-        Parameters
-        ----------
-        ----------
-        - `field` Property name
-        - `value` Integer value to be stored into the property.
+        :param field: Property name
+        :param value: Integer value to be stored into the property.
         """
         return code.Update(field, value)
 
-    def isEqual(self, field: str, value: str):
+    def isEqual(self, field: str, value: str) -> code.IsEqual:
         """Intrinsic operation.
 
-           state[field] &= value
-           return 0;
+        ```c
+        state[field] &= value
+        return 0;
+        ```
 
-        Parameters
-        ----------
-        ----------
-        - `field` Property name
-        - `value` Integer value
+        :param field: Property name
+        :param value: Integer value
         """
         return code.IsEqual(field, value)
 
     # NOTE : Unlike in typescript lowercase "and" & "or"
     # cannot be used this might have to be
     # throughly addressed - Vizonex
-    def And(self, field: str, value: int):
+    def And(self, field: str, value: int) -> code.And:
         """Intrinsic operation.
 
-          state[field] &= value
-          return 0;
+        ```c
+        state[field] &= value
+        return 0;
+        ```
 
-        Parameters
-        ----------
-        ----------
-        - `field` Property name
-        - `value` Integer value"""
+        :param field: Property name
+        :param value: Integer value
+        """
 
         return code.And(field, value)
 
-    def Or(self, field: str, value: int):
+    def Or(self, field: str, value: int) -> code.Or:
         """
         Intrinsic operation.
 
            state[field] |= value
            return 0;
 
-        Parameters
-        ----------
-        ----------
-        - `field` Property name
-        - `value` Integer value
+        :param field: Property name
+        :param value: Integer value
 
         This will allow us to set our own flags at will
         """
         return code.Or(field, value)
 
-    def test(self, field: str, value: str):
+    def test(self, field: str, value: int) -> code.Test:
         """Intrinsic operation.
 
+        ```c
         return (state[field] & value) == value ? 1 : 0;
+        ```
 
-        Parameters
-        ----------
-        ----------
-        - `field` Property name
-        - `value` Integer value
+        :param field: Property name
+        :param value: Integer value
         """
         return code.Test(field, value)
+
+    def is_gt(self, field: str, value: int) -> code.Operator:
+        """Intrinsic operation.
+
+        ```c
+        return (state[field] > value);
+        ```
+
+        :param field: Property name
+        :param value: Integer value
+        """
+
+        return code.Operator(">", field, value)
+
+    def is_lt(self, field: str, value: int) -> code.Operator:
+        """Intrinsic operation.
+
+        ```c
+        return (state[field] < value);
+        ```
+
+        :param field: Property name
+        :param value: Integer value
+        """
+
+        return code.Operator("<", field, value)
+
+    def is_le(self, field: str, value: int) -> code.Operator:
+        """Intrinsic operation.
+
+        ```c
+        return (state[field] <= value);
+        ```
+
+        :param field: Property name
+        :param value: Integer value
+        """
+
+        return code.Operator("<=", field, value)
+
+    def is_ge(self, field: str, value: int) -> code.Operator:
+        """Intrinsic operation.
+
+        ```c
+        return (state[field] >= value);
+        ```
+
+        :param field: Property name
+        :param value: Integer value
+        """
+
+        return code.Operator(">=", field, value)
 
 
 # NOTE: I have Nodes and Codes in the same file called `main_code`
@@ -318,7 +350,7 @@ class Builder:
         """Return list of all allocated properties in parser's state."""
         return list(self.privProperties.values())
 
-    def intBE(self, field: str, bits:int):
+    def intBE(self, field: str, bits: int):
         """
         :param field: State's property name
         :param bits: Number of bits to use
@@ -337,7 +369,7 @@ class Builder:
     def uintBE(self, field: str, bits: int):
         """
         return a node for unpacking arrays to integers
-        
+
         :param field: State's property name
         :param bits: Number of bits to use
         """
@@ -346,9 +378,8 @@ class Builder:
     def uintLE(self, field: str, bits: int):
         """
         return a node for unpacking arrays to integers
-        
+
         :param field: State's property name
         :param bits: Number of bits to use
         """
         return code.Int(field, bits, False, True)
-    

--- a/llparse/pybuilder/main_code.py
+++ b/llparse/pybuilder/main_code.py
@@ -80,6 +80,24 @@ class IsEqual(FieldValue):
         super().__init__("match", "is_equal", field, value)
 
 
+OperatorsMap = {"<": "lt", ">": "gt", ">=": "ge", "<=": "le"}
+
+
+class Operator(FieldValue):
+    """An Operator such as `>, <, >=, <=` made for dealing with
+    properties with infinate sizes"""
+
+    def __init__(self, op: str, field: str, value: int) -> None:
+        if name := OperatorsMap.get(op):
+            super().__init__("match", name, field, value)
+            # Make sure our operator can be remebered for later...
+            self.op = op
+        else:
+            raise NotImplementedError(
+                f"operator {op} not implemented or doesnt exist yet"
+            )
+
+
 class Load(Field):
     def __init__(self, field: str) -> None:
         super().__init__("match", "load", field)
@@ -90,8 +108,6 @@ class _Match(Code):
 
     def __init__(self, name: str) -> None:
         super().__init__("match", name)
-
-
 
 
 @dataclass
@@ -246,38 +262,41 @@ class Invoke(Node):
             self.addEdge(Edge(targetNode, True, numKey, None))
 
 
-
-# Not in llparse node-js (yet) But I wanted to implement 
-# this into my version since I am making a very important 
+# Not in llparse node-js (yet) But I wanted to implement
+# this into my version since I am making a very important
 # http2 frame parser
 
 # SEE: https://github.com/nodejs/llparse-frontend/pull/1
 
-def build_name(field:str, bits: int, signed:bool, little_endian:bool) -> str:
+
+def build_name(field: str, bits: int, signed: bool, little_endian: bool) -> str:
     result = f"{field}_{'int' if signed else 'uint'}_{bits * 8}"
     if bits > 1:
-        return result + ('_le' if little_endian else 'be')
+        return result + ("_le" if little_endian else "be")
     else:
         return result
 
 
 class Int(Node):
     """Used for parsing bytes via unpacking"""
-    def __init__(self, field: str, bits: int, signed: bool, little_endian: bool) -> None:
+
+    def __init__(
+        self, field: str, bits: int, signed: bool, little_endian: bool
+    ) -> None:
         """
         :param field: State's property name
         :param bits: Number of bits to use
-        :param signed: Number is signed 
+        :param signed: Number is signed
         :param little_endian: true if le, false if be
         """
         if bits < 0:
             raise ValueError("bits should be a positive integer")
-        self.field =  field
+        self.field = field
         self.bits = bits
         self.signed = signed
-        self.little_endian  = little_endian
+        self.little_endian = little_endian
         super().__init__(build_name(field, bits, signed, little_endian))
-    
+
 
 # -- Transfroms --
 

--- a/llparse/pyfront/front.py
+++ b/llparse/pyfront/front.py
@@ -86,6 +86,14 @@ class IsEqual(FieldValue):
         )
 
 
+class Operator(FieldValue):
+    def __init__(self, name: str, field: str, value: int, op: str):
+        super().__init__(
+            "match", f"is_{field}_{name}_{toCacheKey(value)}", f'{name}_{toCacheKey(value)}', field, value
+        )
+        self.op = op
+
+
 class Load(Field):
     """Subclass of Field"""
 

--- a/llparse/pyfront/implementation.py
+++ b/llparse/pyfront/implementation.py
@@ -60,6 +60,7 @@ class ICodeImplementation:
     def __init__(self) -> None:
         return
 
+    # TODO: (Vizonex) Transform these functions to lamdas instead to conserve space...
     def And(self, c: code.And):
         return IWrap(c)
 
@@ -91,6 +92,9 @@ class ICodeImplementation:
         return IWrap(c)
 
     def Value(self, c: code.Value):
+        return IWrap(c)
+    
+    def Operator(self, c: code.Operator):
         return IWrap(c)
 
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,22 +1,127 @@
-
 from llparse import LLParse
+from llparse.pybuilder.main_code import Operator
 
+import pytest
+
+
+@pytest.fixture(params=[">", "<", ">=", "<="])
+def op(request: pytest.FixtureRequest) -> str:
+    return request.param
 
 
 def test_build_tables():
     # There was a bug with 1.2 of our version that doesn't affect the node-js one where
-    # it wouldn't building tables, this attempts to simulate the problem Currenlty this 
+    # it wouldn't building tables, this attempts to simulate the problem Currenlty this
     # bug is patched now :)
     p = LLParse("lltable")
-    start = p.node('start')
-    loop = p.node('loop')
+    start = p.node("start")
+    loop = p.node("loop")
     loop.skipTo(start)
     start.match(
-        [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 
-65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 58, 
-59, 60, 61, 62, 63, 64, 91, 92, 93, 94, 95, 96, 123, 124, 125, 126, 32, 9, 10, 13, 11, 12],
-        loop
-    ).otherwise(p.error(0, 'im a little teapot'))
+        [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            97,
+            98,
+            99,
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            112,
+            113,
+            114,
+            115,
+            116,
+            117,
+            118,
+            119,
+            120,
+            121,
+            122,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            88,
+            89,
+            90,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            58,
+            59,
+            60,
+            61,
+            62,
+            63,
+            64,
+            91,
+            92,
+            93,
+            94,
+            95,
+            96,
+            123,
+            124,
+            125,
+            126,
+            32,
+            9,
+            10,
+            13,
+            11,
+            12,
+        ],
+        loop,
+    ).otherwise(p.error(0, "im a little teapot"))
 
     # If there is not a lookup_table this then it has failed me ;-;
     assert "lookup_table" in p.build(start).c
@@ -25,11 +130,35 @@ def test_build_tables():
 def test_pausing():
     # Ensure frotentend LoopChecker does not mark off against Pausing
     p = LLParse("lltest")
-    s = p.node('start')
-    s2 = p.node('start2')
-    s.match('p', p.pause(1, 'parser was asked to pause').otherwise(s2)).skipTo(s)
-    s2.match('p', p.pause(2, 'parser was asked to pause again').otherwise(s)).skipTo(s2)
-    
+    s = p.node("start")
+    s2 = p.node("start2")
+    s.match("p", p.pause(1, "parser was asked to pause").otherwise(s2)).skipTo(s)
+    s2.match("p", p.pause(2, "parser was asked to pause again").otherwise(s)).skipTo(s2)
     p.build(s)
 
-    
+
+def test_operators(op: str):
+    test = LLParse("test")
+
+    test.property("i16", "a")
+
+    node = test.node("node_1")
+    # WARNING: Don't try and do this normally need operator exposed for making fixtures a bit easier.
+    node.match(
+        "1",
+        test.invoke(
+            Operator(op, "a", 10), {1: node}, test.error(1, "a is not greater than 10")
+        ),
+    ).otherwise(test.error(2, "lol"))
+
+    t = test.build(node)
+    code = t.c.splitlines(keepends=False)
+    assert f"  return state->a {op} 10;" in code
+    if op == ">":
+        assert "int test__c_gt_a_10 (" in code
+    elif op == "<":
+        assert "int test__c_lt_a_10 (" in code
+    elif op == ">=":
+        assert "int test__c_ge_a_10 (" in code
+    elif op == "<=":
+        assert "int test__c_le_a_10 (" in code

--- a/tests/test_span_allocator.py
+++ b/tests/test_span_allocator.py
@@ -54,7 +54,7 @@ def test_allocate_overlapping_spans(span_alloc: tuple[SpanAllocator, Builder]) -
     assert res.max == 1
 
     assert len(res.concurrency) == 2
-    
+
     # python loves to shuffle things on me :/ but both exist nevertheless
     assert span2 in res.concurrency[0] or span1 in res.concurrency[0]
     assert span1 in res.concurrency[1] or span2 in res.concurrency[1]
@@ -106,16 +106,22 @@ def test_should_throw_on_loops(span_alloc: tuple[SpanAllocator, Builder]) -> Non
     with pytest.raises(Error, match=r"unmatched.*on_data"):
         sa.allocate(start)
 
-def test_propagate_through_invoke_map(span_alloc:tuple[SpanAllocator, Builder]):
+
+def test_propagate_through_invoke_map(span_alloc: tuple[SpanAllocator, Builder]):
     sa, b = span_alloc
-    start = b.node('start')
-    span = b.span(b.code.span('llparse__on_data'))
+    start = b.node("start")
+    span = b.span(b.code.span("llparse__on_data"))
 
-    b.property('i8', 'custom')
+    b.property("i8", "custom")
 
-    start.otherwise(b.invoke(b.code.load('custom'), {
-      0: span.end().skipTo(start),
-    }, span.end().skipTo(start)))
+    start.otherwise(
+        b.invoke(
+            b.code.load("custom"),
+            {
+                0: span.end().skipTo(start),
+            },
+            span.end().skipTo(start),
+        )
+    )
 
     sa.allocate(span.start(start))
-    


### PR DESCRIPTION
Needed a new Code block for dealing with the following operators `<, >, <=, >=` Hopefully the typescript developers will follow my lead after seeing this. (fingers crossed) I mainly needed this implemented for dealing with http/2 frames since I have an upcoming new frame parser that will hopefully speedup many slow sections of python hyperframe and allow other languages to implement upon it.
