### PR TITLE
Fix SpanStart for frontend

### DIFF
--- a/llparse/frontend.py
+++ b/llparse/frontend.py
@@ -196,6 +196,7 @@ class Frontend:
                 _frontend.node.Sequence,
                 _frontend.node.Single,
                 _frontend.node.TableLookup,
+                _frontend.node.SpanStart
             ),
         ):
             self.resumptionTargets.add(node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llparse"
-version = "0.1.7"
+version = "0.1.8"
 description = "A Parody of llparse written for writing C Parsers with Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Seems I found another bug so I'm gonna Yank 0.1.7 due to how new it is following the rules of aiohttp for releasing packages and release this instead since I forgot about SpanStart being a resumption target as well. I must've been tried when I wrote this originally.